### PR TITLE
Fixes to separate the business lawyer from controller

### DIFF
--- a/server/src/controllers/representantesController.js
+++ b/server/src/controllers/representantesController.js
@@ -3,22 +3,13 @@ const {
   insertRepresentante,
   updateRepresentante,
   removeRepresentante,
+  getAllRepresentantes,
+  getOneRepresentante,
 } = require("../service/representantesService.js");
 
 const getRepresentantes = async (req, res, next) => {
   try {
-    const response = await prisma.representantes.findMany({
-      include: {
-        patrocinador: {
-          include: {
-            infantes: true,
-          },
-        },
-        relacionparentesco: {
-          include: {parentesco : true},
-        },
-      },
-    });
+    const response = await getAllRepresentantes();
     res.status(200).json({
       status: "OK",
       data: { representantes: response },
@@ -30,21 +21,7 @@ const getRepresentantes = async (req, res, next) => {
 
 const getRepresentante = async (req, res, next) => {
   try {
-    const response = await prisma.representantes.findUniqueOrThrow({
-      where: {
-        Representante_id: parseInt(req.params.id),
-      },
-      include: {
-        patrocinador: {
-          include: {
-            infantes: true,
-          },
-        },
-        relacionparentesco: {
-          include: {parentesco : true},
-        },
-      },
-    });
+    const response = await getOneRepresentante(req.params.id);
     res.status(200).json({
       status: "OK",
       data: { representante: response },
@@ -55,10 +32,6 @@ const getRepresentante = async (req, res, next) => {
 };
 
 const postRepresentante = async (req, res, next) => {
-  //TODO: add validation
-
-  //modelo o interfaz de representante
-
   try {
     const response = await insertRepresentante(req.body);
     res.status(200).json({
@@ -84,7 +57,9 @@ const deleteRepresentante = async (req, res, next) => {
   try {
     const id = parseInt(req.params.id);
     const response = await removeRepresentante(id);
-    res.status(200).json({ status: "OK", data: { representanteDeleted: response } });
+    res
+      .status(200)
+      .json({ status: "OK", data: { representanteDeleted: response } });
   } catch (error) {
     next(error);
   }

--- a/server/src/service/representantesService.js
+++ b/server/src/service/representantesService.js
@@ -1,5 +1,36 @@
 const { prisma } = require("../config/prisma");
 
+const getAllRepresentantes = async () => {
+  return await prisma.representantes.findMany({
+    include: {
+      patrocinador: {
+        include: {
+          infantes: true,
+        },
+      },
+      relacionparentesco: {
+        include: { parentesco: true },
+      },
+    },
+  });
+};
+const getOneRepresentante = async (id) => {
+  return await prisma.representantes.findUniqueOrThrow({
+    where: {
+      Representante_id: parseInt(id),
+    },
+    include: {
+      patrocinador: {
+        include: {
+          infantes: true,
+        },
+      },
+      relacionparentesco: {
+        include: { parentesco: true },
+      },
+    },
+  });
+};
 const insertRepresentante = async ({
   Cedula,
   Nombre,
@@ -19,7 +50,11 @@ const insertRepresentante = async ({
           infantes: true,
         },
       },
-      relacionparentesco: true,
+      relacionparentesco: {
+        include: {
+          parentesco: true,
+        },
+      },
     },
     data: {
       Cedula,
@@ -64,7 +99,11 @@ const updateRepresentante = async (
           infantes: true,
         },
       },
-      relacionparentesco: true,
+      relacionparentesco: {
+        include: {
+          parentesco: true,
+        },
+      },
     },
     where: { Representante_id: id },
     data: {
@@ -122,6 +161,8 @@ const removeRepresentante = async (id) =>
   });
 
 module.exports = {
+  getAllRepresentantes,
+  getOneRepresentante,
   insertRepresentante,
   updateRepresentante,
   removeRepresentante,


### PR DESCRIPTION
**Changes**

- Moved the functions get one & all representantes from the controller layer to service layer.
- Improved the response after the operations: update and delete, now they include info from its relational entitie (i.e) parentesco.