### PR TITLE
Little fix to Representante responses in swagger

### DIFF
--- a/server/src/v1/routes/representantesRoutes.js
+++ b/server/src/v1/routes/representantesRoutes.js
@@ -137,7 +137,7 @@ routes.get(
  *                    representante:
  *                     $ref: "#/components/schemas/Representante"
  *       403:
- *         description: Validation result
+ *         description: "Error: Forbidden"
  *         content:
  *            application/json:
  *              schema:
@@ -203,7 +203,7 @@ routes.post(
  *                    representante:
  *                     $ref: "#/components/schemas/Representante"
  *       403:
- *         description: Validation result
+ *         description: "Error: Forbidden"
  *         content:
  *            application/json:
  *              schema:


### PR DESCRIPTION
Changed the response 403 from "Validation result" to "Error: Forbidden"